### PR TITLE
Public and Private keywords Encapsulation

### DIFF
--- a/CSharpPractice/Requirements.txt
+++ b/CSharpPractice/Requirements.txt
@@ -38,3 +38,12 @@ Variables hold a pointer value to that object in memory.
 GradeBook book1 = new GradeBook(); where the GradeBook lives in memory
 You can have multiple variables pointing to same place.
 GradeBook book2 = book1; Copies it.
+
+----Access Modifiers----
+public keyword- encapsulation, closing or hiding details in classes and objects
+AddGrade method encapsulates how a grade is stored in gradebook.
+cannot access grades outside of class because of keyword, public
+private keyword - cannot access outside class
+if you don't explicitly tell C# an access modifier, default is private.
+Fields and data are typically private.
+

--- a/Grades/GradeBook.cs
+++ b/Grades/GradeBook.cs
@@ -19,7 +19,7 @@ namespace Grades
         }
 
         //NullReferenceException, using an uninitialized variable, a variable that points to nothing
-        List<float> grades;
+        private List<float> grades;
 
     }
 }

--- a/Grades/Program.cs
+++ b/Grades/Program.cs
@@ -16,7 +16,7 @@ namespace Grades
 
             GradeBook book2 = book;
             book2.AddGrade(75);
-            
+            //book2.grades Can't access private members outside of class
         }
     }
 }


### PR DESCRIPTION
----Access Modifiers----
public keyword- encapsulation, closing or hiding details in classes and objects
AddGrade method encapsulates how a grade is stored in gradebook.
cannot access grades outside of class because of keyword, public
private keyword - cannot access outside class
if you don't explicitly tell C# an access modifier, default is private.
Fields and data are typically private.